### PR TITLE
Improve Docker workflow and modernize build tooling

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,3 @@
 [tools]
 java = "temurin-25.0.1+8.0.LTS"
+pre-commit = "latest"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ This guide will help you set up your development environment and understand our 
 We use [mise](https://mise.jdx.dev/) to manage tool versions (Java, etc.).
 
 **Install mise:**
+
 ```bash
 curl https://mise.run | sh
 ```
@@ -19,18 +20,19 @@ Or see the [mise installation guide](https://mise.jdx.dev/getting-started.html) 
 
 You need a Docker engine to run PostgreSQL locally. Any of these will work:
 
-| Engine | Install |
-|--------|---------|
-| **Docker Desktop** | [Download](https://www.docker.com/products/docker-desktop/) |
-| **Colima** (macOS) | `brew install colima && colima start` |
-| **OrbStack** (macOS) | [Download](https://orbstack.dev/) |
-| **Rancher Desktop** | [Download](https://rancherdesktop.io/) |
+| Engine               | Install                                                     |
+| -------------------- | ----------------------------------------------------------- |
+| **Docker Desktop**   | [Download](https://www.docker.com/products/docker-desktop/) |
+| **Colima** (macOS)   | `brew install colima && colima start`                       |
+| **OrbStack** (macOS) | [Download](https://orbstack.dev/)                           |
+| **Rancher Desktop**  | [Download](https://rancherdesktop.io/)                      |
 
 ### pre-commit (optional but recommended)
 
 We use [pre-commit](https://pre-commit.com/) to validate documentation links before commits.
 
 **Install pre-commit:**
+
 ```bash
 # macOS
 brew install pre-commit
@@ -40,11 +42,13 @@ pip install pre-commit
 ```
 
 **Enable hooks:**
+
 ```bash
 pre-commit install
 ```
 
 This validates markdown links on every commit. To run manually:
+
 ```bash
 pre-commit run --all-files
 ```
@@ -61,9 +65,12 @@ cd credit-card-lending
 ```
 
 The setup script will:
+
 1. Install Java 25 via mise
 2. Start PostgreSQL via Docker
 3. Build the project
+
+> **Note:** You may see _"Kotlin does not yet support 25 JDK target, falling back to JVM_24"_ during the build. This is harmless — it only affects `buildSrc` build scripts, not application code.
 
 ### Optional: Wiki Clone
 
@@ -117,11 +124,13 @@ Follow the conventions in [`docs/context/conventions.md`](docs/context/conventio
 We follow **Test-Driven Development (TDD)**. See [`docs/context/testing.md`](docs/context/testing.md) for principles.
 
 **Run tests:**
+
 ```bash
 ./gradlew test
 ```
 
 **TDD workflow:**
+
 1. Write a failing test (RED)
 2. Write minimum code to pass (GREEN)
 3. Refactor while staying green (REFACTOR)
@@ -131,14 +140,15 @@ We follow **Test-Driven Development (TDD)**. See [`docs/context/testing.md`](doc
 
 We use **trunk-based development** - all work happens directly on `main`:
 
-| Practice | Description |
-|----------|-------------|
-| No feature branches | Commit directly to `main` |
-| No pull requests | Push directly after local verification |
-| Small commits | Each Red-Green-Refactor cycle = one commit |
-| Always green | Never push failing tests |
+| Practice            | Description                                |
+| ------------------- | ------------------------------------------ |
+| No feature branches | Commit directly to `main`                  |
+| No pull requests    | Push directly after local verification     |
+| Small commits       | Each Red-Green-Refactor cycle = one commit |
+| Always green        | Never push failing tests                   |
 
 **Before pushing:**
+
 ```bash
 ./gradlew build   # Must pass
 git push origin main
@@ -151,6 +161,7 @@ See [`docs/context/conventions.md`](docs/context/conventions.md#git-workflow) fo
 This project uses [intelligent Engineering (iE)](https://github.com/javatarz/credit-card-lending/wiki/intelligent-Engineering) practices with Claude Code.
 
 **Workflow:**
+
 ```bash
 # Start Claude Code
 claude
@@ -164,36 +175,36 @@ claude
 
 ## Useful Commands
 
-| Command | Description |
-|---------|-------------|
-| `./scripts/setup.sh` | One-time development setup |
-| `./gradlew build` | Build all modules |
-| `./gradlew test` | Run all tests |
-| `./gradlew bootRun` | Start the application (auto-starts PostgreSQL) |
-| `./gradlew createModule -PmoduleName=X` | Scaffold a new module |
-| `./gradlew composeUp` | Start PostgreSQL |
-| `./gradlew composeDown` | Stop PostgreSQL |
-| `docker-compose logs -f` | View PostgreSQL logs |
+| Command                                 | Description                                    |
+| --------------------------------------- | ---------------------------------------------- |
+| `./scripts/setup.sh`                    | One-time development setup                     |
+| `./gradlew build`                       | Build all modules                              |
+| `./gradlew test`                        | Run all tests                                  |
+| `./gradlew bootRun`                     | Start the application (auto-starts PostgreSQL) |
+| `./gradlew createModule -PmoduleName=X` | Scaffold a new module                          |
+| `./gradlew composeUp`                   | Start PostgreSQL                               |
+| `./gradlew composeDown`                 | Stop PostgreSQL (preserves data)               |
+| `docker-compose logs -f`                | View PostgreSQL logs                           |
 
 ## Application URLs
 
 When running locally:
 
-| URL | Description |
-|-----|-------------|
-| http://localhost:8080 | API |
-| http://localhost:8080/swagger-ui.html | Swagger UI |
+| URL                                   | Description  |
+| ------------------------------------- | ------------ |
+| http://localhost:8080                 | API          |
+| http://localhost:8080/swagger-ui.html | Swagger UI   |
 | http://localhost:8080/actuator/health | Health check |
 
 ## Documentation
 
-| Type | Location |
-|------|----------|
+| Type                  | Location                                                            |
+| --------------------- | ------------------------------------------------------------------- |
 | Architecture & Design | [GitHub Wiki](https://github.com/javatarz/credit-card-lending/wiki) |
-| Technical Decisions | [`docs/adr/`](docs/adr/) |
-| Code Conventions | [`docs/context/conventions.md`](docs/context/conventions.md) |
-| Testing Strategy | [`docs/context/testing.md`](docs/context/testing.md) |
-| Current State | [`docs/context/current-state.md`](docs/context/current-state.md) |
+| Technical Decisions   | [`docs/adr/`](docs/adr/)                                            |
+| Code Conventions      | [`docs/context/conventions.md`](docs/context/conventions.md)        |
+| Testing Strategy      | [`docs/context/testing.md`](docs/context/testing.md)                |
+| Current State         | [`docs/context/current-state.md`](docs/context/current-state.md)    |
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The credit card lending domain is intentionally complex (PCI compliance, fraud d
 
 [![Watch: Codifying Engineering Culture](https://img.youtube.com/vi/oK0N7pQ5rIY/maxresdefault.jpg)](https://www.youtube.com/watch?v=oK0N7pQ5rIY&list=PLY67XcOB0u1QhUHMtg9C1ddx8CO2FAf8I)
 
-*[Watch the full playlist](https://www.youtube.com/playlist?list=PLY67XcOB0u1QhUHMtg9C1ddx8CO2FAf8I) for more videos on intelligent Engineering.*
+_[Watch the full playlist](https://www.youtube.com/playlist?list=PLY67XcOB0u1QhUHMtg9C1ddx8CO2FAf8I) for more videos on intelligent Engineering._
 
 ## What is This?
 
@@ -93,13 +93,13 @@ iE uses AI (Claude Code) as a collaborative partner throughout development:
 
 ### Techniques Used Here
 
-| Technique | Purpose |
-|-----------|---------|
-| **Context Documentation** (`docs/context/`) | Dense, factual docs optimized for LLM consumption |
-| **CLAUDE.md** | Project-specific instructions Claude Code reads automatically |
-| **Slash Commands** | `/pickup`, `/start-dev`, `/update-context` for workflow automation |
-| **Story Template** | Every story includes "Context Docs to Update" section |
-| **TDD Workflow** | Red-Green-Refactor cycle with AI assistance |
+| Technique                                   | Purpose                                                            |
+| ------------------------------------------- | ------------------------------------------------------------------ |
+| **Context Documentation** (`docs/context/`) | Dense, factual docs optimized for LLM consumption                  |
+| **CLAUDE.md**                               | Project-specific instructions Claude Code reads automatically      |
+| **Slash Commands**                          | `/pickup`, `/start-dev`, `/update-context` for workflow automation |
+| **Story Template**                          | Every story includes "Context Docs to Update" section              |
+| **TDD Workflow**                            | Red-Green-Refactor cycle with AI assistance                        |
 
 ### The Workflow
 
@@ -139,6 +139,7 @@ cd credit-card-lending
 ```
 
 The application will be available at:
+
 - API: http://localhost:8080
 - Swagger UI: http://localhost:8080/swagger-ui.html
 - Health: http://localhost:8080/actuator/health
@@ -161,14 +162,14 @@ claude
 
 ## Documentation
 
-| What | Where | Audience |
-|------|-------|----------|
-| **Design & Architecture** | [GitHub Wiki](https://github.com/javatarz/credit-card-lending/wiki) | Humans |
-| **Context Documentation** | [`docs/context/`](docs/context/) | Claude Code / LLMs |
-| **Technical Decisions** | [`docs/adr/`](docs/adr/) | Both |
-| **Epics & Stories** | [GitHub Issues](https://github.com/javatarz/credit-card-lending/issues) | Both |
-| **Claude Code Instructions** | [`CLAUDE.md`](CLAUDE.md) | Claude Code |
-| **API Documentation** | [Swagger UI](http://localhost:8080/swagger-ui.html) | Both |
+| What                         | Where                                                                   | Audience           |
+| ---------------------------- | ----------------------------------------------------------------------- | ------------------ |
+| **Design & Architecture**    | [GitHub Wiki](https://github.com/javatarz/credit-card-lending/wiki)     | Humans             |
+| **Context Documentation**    | [`docs/context/`](docs/context/)                                        | Claude Code / LLMs |
+| **Technical Decisions**      | [`docs/adr/`](docs/adr/)                                                | Both               |
+| **Epics & Stories**          | [GitHub Issues](https://github.com/javatarz/credit-card-lending/issues) | Both               |
+| **Claude Code Instructions** | [`CLAUDE.md`](CLAUDE.md)                                                | Claude Code        |
+| **API Documentation**        | [Swagger UI](http://localhost:8080/swagger-ui.html)                     | Both               |
 
 ### Key Context Documents
 
@@ -180,6 +181,8 @@ claude
 ## Tech Stack
 
 Java 25 LTS, Spring Boot 4.x, PostgreSQL 16.x, Gradle 9.x.
+
+> **Note:** You may see a warning during builds: _"Kotlin does not yet support 25 JDK target, falling back to JVM_24"_. This only affects the `buildSrc` Kotlin DSL compilation and has no impact on application code. It will resolve once Gradle bundles a Kotlin version with JDK 25 support.
 
 See [`docs/context/overview.md`](docs/context/overview.md) for full tech stack and [ADR-003](docs/adr/ADR-003-technology-stack.md) for rationale.
 
@@ -194,6 +197,7 @@ See [`docs/context/overview.md`](docs/context/overview.md) for full architecture
 See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and contribution guidelines.
 
 **Quick contribution workflow:**
+
 1. Run `/pickup` to assign yourself a story
 2. Run `/start-dev` to begin TDD development
 3. Follow the Red-Green-Refactor cycle
@@ -204,7 +208,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions and contribution g
 
 Using this workflow, the Customer module (registration, email verification, profile management with PCI-compliant SSN encryption) was built entirely with AI assistance using TDD. Every commit in this repo was created with Claude Code.
 
-*Have you used iE patterns in your own project? [Open a discussion](https://github.com/javatarz/credit-card-lending/discussions) to share your experience.*
+_Have you used iE patterns in your own project? [Open a discussion](https://github.com/javatarz/credit-card-lending/discussions) to share your experience._
 
 <!-- TODO: Add links to blog posts and case studies as they're published -->
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16
+    image: postgres:16-alpine
     container_name: credit-card-platform-db
     environment:
       POSTGRES_DB: credit_card_platform

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,4 @@ springBootVersion=4.0.0-RC1
 springDependencyManagementVersion=1.1.7
 springdocVersion=2.7.0
 postgresqlVersion=42.7.4
-liquibaseVersion=4.30.0
 junitVersion=5.11.3

--- a/platform/api-gateway/build.gradle.kts
+++ b/platform/api-gateway/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 val springdocVersion: String by project
 val postgresqlVersion: String by project
-val liquibaseVersion: String by project
 
 dependencies {
     implementation(project(":shared:kernel"))
@@ -26,7 +25,7 @@ dependencies {
 
     // Database
     runtimeOnly("org.postgresql:postgresql:$postgresqlVersion")
-    implementation("org.liquibase:liquibase-core:$liquibaseVersion")
+    implementation("org.springframework.boot:spring-boot-starter-liquibase")
 
     // Testing
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/platform/api-gateway/build.gradle.kts
+++ b/platform/api-gateway/build.gradle.kts
@@ -41,6 +41,15 @@ dockerCompose {
     useComposeFiles.add("../../docker-compose.yml")
     waitForTcpPorts.set(true)
     stopContainers.set(false) // Keep containers running after task completes
+    removeVolumes.set(false) // Preserve database data on composeDown
+}
+
+// composeDown (plugin-generated) only stops containers it started in the same session.
+// Since stopContainers=false, containers outlive the Gradle process, making composeDown a no-op.
+// Override to always use forced behavior so it reliably stops containers.
+tasks.named("composeDown") {
+    actions.clear()
+    dependsOn("composeDownForced")
 }
 
 tasks.named("bootRun") {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -54,12 +54,7 @@ if ! docker info &> /dev/null; then
 fi
 echo -e "${GREEN}✓${NC} Docker daemon is running"
 
-# 5. Start PostgreSQL via docker-compose
-echo "Starting PostgreSQL..."
-docker-compose up -d
-echo -e "${GREEN}✓${NC} PostgreSQL is running"
-
-# 6. Build the project
+# 5. Build the project
 echo "Building the project (this may take a few minutes on first run)..."
 ./gradlew build
 echo -e "${GREEN}✓${NC} Build successful"


### PR DESCRIPTION
## Summary

- Switch to `postgres:16-alpine` for smaller Docker image
- Fix `composeDown` to reliably stop containers (overrides plugin default which is a no-op when `stopContainers=false`)
- Preserve database volumes on `composeDown`
- Remove redundant `docker-compose up` from `setup.sh` (Gradle handles it via `bootRun`)
- Use Spring Boot managed Liquibase dependency instead of explicit version
- Add `pre-commit` to mise-managed tools
- Fix markdown table alignment and add JDK 25 build note to docs

## Test plan

- [x] Run `./gradlew bootRun` — Liquibase migrations run, app starts successfully
- [x] Run `./gradlew composeDown` — PostgreSQL container stops reliably
- [x] Run `./gradlew composeUp` then `composeDown` — database data preserved across restarts
- [x] Run `scripts/setup.sh` — completes without errors
- [x] Verify PostgreSQL container uses `postgres:16-alpine` image